### PR TITLE
Fix paths in Windows

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -26,7 +26,11 @@ async function readIcons (options = {}) {
     process
   } = options
   const selectedIcons = (typeof icons === 'string' ? [icons] : icons)
-    .map((n) => path.resolve(__dirname, '..', ICON_SRC_DIR, `${n}.svg`))
+    .map((n) =>
+      path
+        .resolve(__dirname, '..', ICON_SRC_DIR, `${n}.svg`)
+        .replace(/\\/g, '/')
+    )
   const selectedIconFiles = await fg(selectedIcons)
   const includedIconFiles = await fg(include)
   const files = [...selectedIconFiles, ...includedIconFiles]


### PR DESCRIPTION
My team is integrating Rivet Icons v1.0.0 in one of our projects. Both developers on the team that uses Windows is unable to properly build the icons.

When the library generates the paths to the SVG icons to read them, `path.resolve()` returns paths on Windows with double backslashes. The first backslash escapes the second. The use of backslashes in paths is the convention for Windows. However, these paths are then passed to `fast-glob`. [As of v3.0.0](https://github.com/mrmlnc/fast-glob/issues/237), that library will only bother with paths in the Unix forward-slash style. The [recommended solution](https://github.com/mrmlnc/fast-glob/tree/3.2.5#how-to-write-patterns-on-windows) is to just replace the slashes.

This PR is just following this recommendation. This fix did work on the Windows environment that we were using.

This would result in a v1.0.1 patch release.