### PR TITLE
Styles should not assume the rvt-icon will be defined

### DIFF
--- a/src/rivet-icon-element.css
+++ b/src/rivet-icon-element.css
@@ -7,7 +7,8 @@ rvt-icon {
 	width: min-content;
 }
 
-rvt-icon:not(:defined)::before {
+rvt-icon:empty::before,
+rvt-icon > svg {
 	content: "";
 	display: block;
 	height: 1rem;


### PR DESCRIPTION
The CSS selector `rvt-icon:not(:defined)::before` assumes that the Rivet Icon Element will be defined. However, there may be a case in which the user wants to use an icon but have it statically rendered by manually copying the icon SVG code (due to server-side rendering or restrictive front-end environments).

```html
<rvt-icon>
  <svg…>
</rvt-icon>
```

Instead, by updating that selector to `rvt-icon:empty::before`, it means that the initial loading style (16px square pseudo element) will only be applied if the element is empty (such as waiting for the custom element to be defined) — not when there is something there (such as when SVG is manually included or when the custom element is attached to the DOM).

This PR solves the same issue found in https://github.com/indiana-university/rivet-stickers/pull/6.