### PR TITLE
Static register method

### DIFF
--- a/src/rivet-icon-element.js
+++ b/src/rivet-icon-element.js
@@ -19,35 +19,7 @@ style.setAttribute(`data-${elementName}`, '');
 document.head.appendChild(style);
 
 export function registerIcon (name, content) {
-	if (!name || typeof name !== 'string') {
-		throw new Error(`${packageName}: Name must be a string.`);
-	}
-	const template = document.createElement('template');
-	template.innerHTML = content;
-	if (template.content.children.length !== 1) {
-		throw new Error(`${packageName} (${name}): Content must contain one SVG element.`);
-	}
-	const svg = template.content.firstChild;
-	if (svg.nodeName.toLowerCase() !== 'svg') {
-		throw new Error(`${packageName} (${name}): Content must be a SVG element.`);
-	}
-	setDefaultAttributes(svg, {
-		'aria-hidden': 'true',
-		fill: 'currentColor',
-		focusable: 'false',
-		height: size,
-		viewBox: `0 0 ${size} ${size}`,
-		width: size,
-		xmlns: 'http://www.w3.org/2000/svg'
-	});
-	nameToTemplateMap.set(name, template);
-	const index = nameToTemplateMap.size;
-	indexToNameMap.set(index, name);
-	style.sheet.insertRule(`${elementName} { --${name}: ${index}; }`);
-	const event = new CustomEvent(registeredEventName, {
-		detail: { name }
-	});
-	document.dispatchEvent(event);
+	window.customElements.get(elementName).register?.(name, content);
 }
 
 class RivetIconElement extends window.HTMLElement {
@@ -56,6 +28,38 @@ class RivetIconElement extends window.HTMLElement {
 
 	static get observedAttributes () {
 		return [nameAttributeName];
+	}
+
+	static register (name, content) {
+		if (!name || typeof name !== 'string') {
+			throw new Error(`${packageName}: Name must be a string.`);
+		}
+		const template = document.createElement('template');
+		template.innerHTML = content;
+		if (template.content.children.length !== 1) {
+			throw new Error(`${packageName} (${name}): Content must contain one SVG element.`);
+		}
+		const svg = template.content.firstChild;
+		if (svg.nodeName.toLowerCase() !== 'svg') {
+			throw new Error(`${packageName} (${name}): Content must be a SVG element.`);
+		}
+		setDefaultAttributes(svg, {
+			'aria-hidden': 'true',
+			fill: 'currentColor',
+			focusable: 'false',
+			height: size,
+			viewBox: `0 0 ${size} ${size}`,
+			width: size,
+			xmlns: 'http://www.w3.org/2000/svg'
+		});
+		nameToTemplateMap.set(name, template);
+		const index = nameToTemplateMap.size;
+		indexToNameMap.set(index, name);
+		style.sheet.insertRule(`${elementName} { --${name}: ${index}; }`);
+		const event = new CustomEvent(registeredEventName, {
+			detail: { name }
+		});
+		document.dispatchEvent(event);
 	}
 
 	attributeChangedCallback () {


### PR DESCRIPTION
This PR addresses issues in #109. @burnumd and I discussed this approach today, and we would like to move forward with this direction.

## Problems
1. Rivet React needs a certain set of icons.
2. Client apps may or may not need icons.
3. What should Rivet React require of client apps in order to bring in its icons?
4. How do we minimize importing redundant JS modules in either Rivet React or the client app?

## Patch update (v3.0.1)
1. This PR would result in a patch update.
2. Check if `rvt-icon` is already defined before defining it. This avoids a console error if both Rivet React and the client app import their own instance of Rivet Icons.
3. Move the content of the `registerIcon()` function to the static method `RivetIconElement.register()`.
4. Calls to `registerIcon()` will now call the static `register()` method on whichever `RivetIconElement` class is defined first (the one declared by Rivet React or the one declared by the client app).
5. Rivet React will make v3.0.1 a required peer dependency.
6. This patch update should also include the changes in #108.

## Breaking update (v4.0.0)
1. A future PR would make the following breaking changes to clean up what happened in this PR.
2. The `registerIcon()` function is removed, with a requirement to instead use `window.customElements.get(elementName).register?.(name, content);`
3. The `rvtIconRegistered` global event is replaced with explicit calls on element instances (`document.querySelectorAll('rvt-icon').forEach((el) => el.update())`);
4. The custom element is now required to be imported (`<script type="module" src="https://unpkg.com/rivet-icons/dist/rivet-icon-element.js"></script>`).
5. Rivet React will no longer implicitly and redundantly import `rivet-icon-element.js`.
7. Rivet React will make v4.0.0 a required peer dependency.

## Rivet Stickers
1. These changes and approach should also be duplicated in the next Rivet Stickers releases.

## Questions
1. Should we raise a warning if the same icon is registered more than once?
2. Should the first registration of an icon win (like what happens with `customElements.define()`), or should the last registration win (so you can override icons)? Should there be a warning associated with this?